### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,10 @@ exports.extract = function (cwd, opts) {
     var onlink = function () {
       if (win32) return next() // skip links on win for now before it can be tested
       xfs.unlink(name, function () {
+        if (header.linkname.indexOf('..') !== -1) {
+          console.log('skipping bad path', header.linkname);
+          return next();
+        }
         var srcpath = path.resolve(cwd, header.linkname)
 
         xfs.link(srcpath, name, function (err) {


### PR DESCRIPTION
Fixes [https://github.com/ericgorg/code-scanning-javascript-demo/security/code-scanning/1](https://github.com/ericgorg/code-scanning-javascript-demo/security/code-scanning/1)

To fix the problem, we need to ensure that the `header.linkname` does not contain any directory traversal sequences like `..`. This can be done by validating the path before using it in any file system operations.

The best way to fix this without changing existing functionality is to add a validation step that checks if `header.linkname` contains any `..` sequences. If it does, we should skip processing that entry and log a warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
